### PR TITLE
09 13 18

### DIFF
--- a/functions.cpp
+++ b/functions.cpp
@@ -2,14 +2,13 @@
 
 #include <fstream>
 #include <vector>
+#include <set>
 #include <string>
 #include <filesystem>
 #include <cstdlib> // for rand() and srand()
 #include <QString>
 #include <QMessageBox>
 #include <QUrl>
-
-#include <set> // for readinallkits
 
 #include "variables.h"
 #include "actor.h"
@@ -261,9 +260,9 @@ void loadMod(const std::string &modPath, std::vector<Actor> &actors, Strings &st
     // read in guns, projectiles, and items if there is an "equip" folder
     if (fs::is_directory(modPath + "\\Equip", errorCode))
     {
-        readInGameFiles(modPath + "\\Equip", gunExtension, guns, strings);
-        readInGameFiles(modPath + "\\Equip", projectileExtension, projectiles, strings);
-        readInGameFiles(modPath + "\\Equip", itemExtension, items, strings);
+        readInGameFiles(modPath + "\\Equip", gunExtension, guns);
+        readInGameFiles(modPath + "\\Equip", projectileExtension, projectiles);
+        readInGameFiles(modPath + "\\Equip", itemExtension, items);
     }
 
     // add/update any new kits discovered in this mod
@@ -277,19 +276,33 @@ void loadMod(const std::string &modPath, std::vector<Actor> &actors, Strings &st
         currentFile.close();
     }
 
-    // update the music track if there are newer versions of them
-    if (fs::is_regular_file(modPath + "\\Sound\\Music\\action3.wav", errorCode))
-        musicAction3 = modPath + "\\Sound\\Music\\action3.wav";
-    if (fs::is_regular_file(modPath + "\\Sound\\Music\\load1.wav", errorCode))
-        musicLoad1 = modPath + "\\Sound\\Music\\load1.wav";
-    if (fs::is_regular_file(modPath + "\\Sound\\Music\\load3.wav", errorCode))
-        musicLoad3 = modPath + "\\Sound\\Music\\load3.wav";
-
-    // update the sound effects if there are newer versions of them
-    if (fs::is_regular_file(modPath + "\\Sound\\I_main1.wav", errorCode))
-        soundButton = modPath + "\\Sound\\I_main1.wav";
-    if (fs::is_regular_file(modPath + "\\Sound\\I_launch5.wav", errorCode))
-        soundApply = modPath + "\\Sound\\I_launch5.wav";
+    // update the music tracks and sound effects if there are newer versions of them
+    for (const auto &element : fs::recursive_directory_iterator(modPath))
+    {
+        QString curFilePath{QString::fromStdWString(element.path())};
+        QString curFileName{QString::fromStdWString(element.path().filename())};
+        std::error_code errorCode;
+        if ((QString::compare(curFileName, "action3.wav", Qt::CaseInsensitive) == 0) && fs::is_regular_file(element.path(), errorCode))
+        {
+            musicAction3 = curFilePath.toStdString();
+        }
+        else if ((QString::compare(curFileName, "load1.wav", Qt::CaseInsensitive) == 0) && fs::is_regular_file(element.path(), errorCode))
+        {
+            musicLoad1 = curFilePath.toStdString();
+        }
+        else if ((QString::compare(curFileName, "load3.wav", Qt::CaseInsensitive) == 0) && fs::is_regular_file(element.path(), errorCode))
+        {
+            musicLoad3 = curFilePath.toStdString();
+        }
+        else if ((QString::compare(curFileName, "I_main1.wav", Qt::CaseInsensitive) == 0) && fs::is_regular_file(element.path(), errorCode))
+        {
+            soundButton = curFilePath.toStdString();
+        }
+        else if ((QString::compare(curFileName, "I_launch5.wav", Qt::CaseInsensitive) == 0) && fs::is_regular_file(element.path(), errorCode))
+        {
+            soundApply = curFilePath.toStdString();
+        }
+    }
 }
 
 // randomly chooses actors from one vector and places them into another vector if that actor isn't already in there

--- a/functions.h
+++ b/functions.h
@@ -27,6 +27,7 @@ QString getFileExtension(const QString &fileName);
 QUrl stringToQUrl(const std::string &string);
 
 // reads in all kits from the passed in directory and it's subdirectories and stores them in a kit vector
+// maintains a list of discovered kit file names so that only the first discoverd kit will be processed just like the game does
 void readInAllKits(const std::string &kitsDirectoryPath, std::vector<Kit> &kitVector);
 
 // adds kits from the passed in source kit vector to the destination kit vector based on whether or not a kit's path matches the passed in kit path
@@ -37,8 +38,8 @@ void updateKitVectorPerKitPath(const QString &targetKitPath, const std::vector<K
 // a kit could be used by more than one soldier class
 void updateKitVectorsPerRestrictionList(const std::vector<Kit> &allKits, const KitRestrictionList &kitList, std::vector<Kit> &riflemanKits, std::vector<Kit> &heavyWeaponsKits, std::vector<Kit> &sniperKits, std::vector<Kit> &demolitionsKits);
 
-// reads in actor files
-// pass in a directory where actor files are held, the file extension of the desired file type, and a vector of the desired file type to store the results
+// reads in actor, gun, projectile, or item files
+// pass in a directory where actor, gun, projectile, or item files are held, the file extension of the desired file type, and a vector of the desired file type to store the results
 template <typename T>
 void readInGameFiles(const std::string &directoryPath, const QString &targetFileExtension, T &gameDataVector)
 {
@@ -81,6 +82,7 @@ void readInGameFiles(const std::string &directoryPath, const QString &targetFile
 
 // reads in gun, projectile, or item files
 // pass in a directory where gun, projectile, or item files are held, the file extension of the desired file type, and a vector of the desired file type to store the results
+/*
 template <typename T>
 void readInGameFiles(const std::string &directoryPath, const QString &targetFileExtension, T &gameDataVector, const Strings &strings)
 {
@@ -120,6 +122,7 @@ void readInGameFiles(const std::string &directoryPath, const QString &targetFile
         currentFile.close();
     }
 }
+*/
 
 // pass in a directory where actor files are held and a vector of actors.  will update the passed in vector with newer versions of the files it finds
 void updateActorFiles(const std::string &actorDirectoryPath, std::vector<Actor> &actors);

--- a/functions.h
+++ b/functions.h
@@ -80,50 +80,6 @@ void readInGameFiles(const std::string &directoryPath, const QString &targetFile
     }
 }
 
-// reads in gun, projectile, or item files
-// pass in a directory where gun, projectile, or item files are held, the file extension of the desired file type, and a vector of the desired file type to store the results
-/*
-template <typename T>
-void readInGameFiles(const std::string &directoryPath, const QString &targetFileExtension, T &gameDataVector, const Strings &strings)
-{
-    for (const auto &element : fs::directory_iterator(directoryPath))
-    {
-        std::ifstream currentFile;
-        std::error_code errorCode; // no actual error handling will take place with this error code
-        if (fs::is_regular_file(element.path(), errorCode))
-        {
-            QString curFileName{QString::fromStdWString(element.path().filename())};
-            if (QString::compare(getFileExtension(curFileName), targetFileExtension, Qt::CaseInsensitive) == 0)  // check the extension of the current iteration file matches what was passed in
-            {
-                currentFile.open(element.path());
-                if (!currentFile.good())
-                {
-                    QString errorMsg{"Error in readInGameFiles().  Failed to open file: "};
-                    errorMsg += QString::fromStdWString(element.path());
-                    QMessageBox msgBox(QMessageBox::Critical, "Error", errorMsg);
-                    msgBox.exec();
-                    exit(EXIT_FAILURE);
-                }
-                bool replacedItem{false};
-                for (auto &element2 : gameDataVector)
-                {
-                    if (QString::compare(curFileName, element2.getFileName(), Qt::CaseInsensitive) == 0) // found an item in the vector with same filename as this one, replace it with this new one
-                    {
-                        element2 = typename T::value_type(curFileName, currentFile, strings);
-                        replacedItem = true;
-                    }
-                }
-                if (!replacedItem) // didn't find an item in the vector with this name already so add in this new item
-                {
-                    gameDataVector.push_back(typename T::value_type(curFileName, currentFile, strings));
-                }
-            }
-        }
-        currentFile.close();
-    }
-}
-*/
-
 // pass in a directory where actor files are held and a vector of actors.  will update the passed in vector with newer versions of the files it finds
 void updateActorFiles(const std::string &actorDirectoryPath, std::vector<Actor> &actors);
 

--- a/gun.cpp
+++ b/gun.cpp
@@ -1,6 +1,5 @@
 #include "gun.h"
 #include "variables.h"
-#include "strings.h"
 
 #include <fstream>
 #include <vector>
@@ -8,11 +7,10 @@
 #include <QMessageBox>
 #include <QTextStream> // for printing to console
 
-Gun::Gun(QString fileName, std::ifstream &gunFile, const Strings &strings)
+Gun::Gun(QString fileName, std::ifstream &gunFile)
     : m_fileName(fileName)
 {
     getGameData(m_nameTokenTag, m_nameToken, gunFile);
-    m_name = strings.getString(m_nameToken);
     getGameData(m_magCapTag, m_magCap, gunFile);
     getGameData(m_maxRangeTag, m_maxRange, gunFile);
     getGameData(m_muzzleVelocityTag, m_muzzleVelocity, gunFile);

--- a/gun.h
+++ b/gun.h
@@ -45,7 +45,7 @@ private:
     fileReadResult getMaxZoom(QString &valueToFill, std::ifstream &gunFile, int startReadingPos);
 
 public:
-    Gun(QString fileName, std::ifstream &gunFile, const Strings &strings);
+    Gun(QString fileName, std::ifstream &gunFile);
 
     ~Gun()
     {
@@ -63,6 +63,8 @@ public:
     const QString& getSilenced() const {return m_silenced;}
     const QString& getMaxZoom() const {return m_maxZoom;}
     const std::vector<FireMode>& getFireModes() const {return m_fireModes;}
+
+    void setNameFromStrings(const Strings &strings) {m_name = strings.getString(m_nameToken);}
 
     Gun& operator= (const Gun &gun);
 

--- a/item.cpp
+++ b/item.cpp
@@ -1,6 +1,6 @@
 #include "item.h"
 
-Item::Item(QString fileName, std::ifstream &itemFile, const Strings &strings)
-    : Projectile(fileName, itemFile, strings)
+Item::Item(QString fileName, std::ifstream &itemFile)
+    : Projectile(fileName, itemFile)
 {
 }

--- a/item.h
+++ b/item.h
@@ -7,7 +7,7 @@
 class Item : public Projectile
 {
 public:
-    Item(QString fileName, std::ifstream &itemFile, const Strings &strings);
+    Item(QString fileName, std::ifstream &itemFile);
 
     ~Item()
     {

--- a/platoonsetup.cpp
+++ b/platoonsetup.cpp
@@ -111,9 +111,9 @@ PlatoonSetup::PlatoonSetup(QWidget *parent) :
     // read in guns, projectiles, and items
     if (fs::is_directory(mainGameDirectory + "\\Mods\\Origmiss\\Equip", errorCode) && !errorLoadingBaseGameData)
     {
-        readInGameFiles(mainGameDirectory + "\\Mods\\Origmiss\\Equip", gunExtension, m_guns, m_strings);
-        readInGameFiles(mainGameDirectory + "\\Mods\\Origmiss\\Equip", projectileExtension, m_projectiles, m_strings);
-        readInGameFiles(mainGameDirectory + "\\Mods\\Origmiss\\Equip", itemExtension, m_items, m_strings);
+        readInGameFiles(mainGameDirectory + "\\Mods\\Origmiss\\Equip", gunExtension, m_guns);
+        readInGameFiles(mainGameDirectory + "\\Mods\\Origmiss\\Equip", projectileExtension, m_projectiles);
+        readInGameFiles(mainGameDirectory + "\\Mods\\Origmiss\\Equip", itemExtension, m_items);
     }
     else if (!errorLoadingBaseGameData)
     {
@@ -232,6 +232,11 @@ PlatoonSetup::PlatoonSetup(QWidget *parent) :
     {
         loadMod(mainGameDirectory + currentMod, m_actors, m_strings, m_guns, m_projectiles, m_items, tempKits, kitList, musicAction3, musicLoad1, musicLoad3, soundButton, soundApply);
     }
+
+    // have the guns, projectiles, and items get their names from the strings object (must do after loading mods as mods may changes strings)
+    for (auto &element : m_guns) {element.setNameFromStrings(m_strings);}
+    for (auto &element : m_projectiles) {element.setNameFromStrings(m_strings);}
+    for (auto &element : m_items) {element.setNameFromStrings(m_strings);}
 
     // identify the kit paths of each soldier class (must do after loading mods as mods may change actor kit paths)
     QString riflemanKitPath{"no kit path"};

--- a/platoonsetup.ui
+++ b/platoonsetup.ui
@@ -889,7 +889,7 @@ QPushButton:pressed {
      </font>
     </property>
     <property name="text">
-     <string>Max Accuracy</string>
+     <string>Min Inaccuracy</string>
     </property>
    </widget>
    <widget class="QLineEdit" name="leAccuracy1">

--- a/projectile.cpp
+++ b/projectile.cpp
@@ -1,17 +1,15 @@
 #include "projectile.h"
 #include "variables.h"
-#include "strings.h"
 
 #include <fstream>
 #include <QString>
 #include <QMessageBox>
 #include <QTextStream> // for printing to console
 
-Projectile::Projectile(QString fileName, std::ifstream &projectileFile, const Strings &strings)
+Projectile::Projectile(QString fileName, std::ifstream &projectileFile)
     : m_fileName(fileName)
 {
     getGameData(m_nameTokenTag, m_nameToken, projectileFile);
-    m_name = strings.getString(m_nameToken);
 }
 
 // reads and stores one item of game data from a projectile file

--- a/projectile.h
+++ b/projectile.h
@@ -18,7 +18,7 @@ private:
     fileReadResult getGameData(const QString &targetTag, QString &valueToFill, std::ifstream &projectileFile);
 
 public:
-    Projectile(QString fileName, std::ifstream &projectileFile, const Strings &strings);
+    Projectile(QString fileName, std::ifstream &projectileFile);
 
     ~Projectile()
     {
@@ -26,6 +26,8 @@ public:
 
     const QString& getFileName() const {return m_fileName;}
     const QString& getName() const {return m_name;}
+
+    void setNameFromStrings(const Strings &strings) {m_name = strings.getString(m_nameToken);}
 
     Projectile& operator= (const Projectile &projectile);
 

--- a/strings.cpp
+++ b/strings.cpp
@@ -3,7 +3,6 @@
 
 #include <fstream>
 #include <map>
-#include <utility> // for std::make_pair
 #include <QString>
 #include <QMessageBox>
 


### PR DESCRIPTION
- Changed how guns, projectiles, and items retrieve their strings from the strings object.  No longer do they do it at creation and during loading of mods.  Now they only do it after all mods have been loaded.  This is to correct an issue with mods that only feature new strings for existing guns/projectiles/items.  The new string wasn't being applied because no new item was being created, only the strings file was being updated.

- Changed how loadMod() looks for updated music and sound effects.  It now searches the whole mod directory instead of the predefined paths.  This better matches how the game engine does it as the old method failed while testing the Year of the Monkey Mod.

- Changed "Max Accuracy" to "Min Inaccuracy" to better reflect what the value actually means.  It's more obvious now for the user that a lower value is better.