### PR TITLE
Add files via upload

### DIFF
--- a/functions.cpp
+++ b/functions.cpp
@@ -462,7 +462,11 @@ void writeAvatarFile(const std::vector<Actor*> &alpha, const std::vector<Actor*>
             idNumber = alpha.size() + bravo.size() + charlie.size() + 1;
             (alphaTeam += '"') += QString::number(idNumber);
             alphaTeam += R"(" ScriptId = "0" Name = "_Alpha">)";
-            alphaTeam += alphaStrings[0] += alphaStrings[1] += alphaStrings[2] += "\n\t\t\t</Team>";
+            for (int i{0}; i < alpha.size(); ++i)
+            {
+                alphaTeam += alphaStrings[i];
+            }
+            alphaTeam += "\n\t\t\t</Team>";
         }
 
         // create bravo team
@@ -474,7 +478,11 @@ void writeAvatarFile(const std::vector<Actor*> &alpha, const std::vector<Actor*>
             if (alpha.size() > 0) { ++idNumber;}
             (bravoTeam += '"') += QString::number(idNumber);
             bravoTeam += R"(" ScriptId = "0" Name = "_Bravo">)";
-            bravoTeam += bravoStrings[0] += bravoStrings[1] += bravoStrings[2] += "\n\t\t\t</Team>";
+            for (int i{0}; i < bravo.size(); ++i)
+            {
+                bravoTeam += bravoStrings[i];
+            }
+            bravoTeam += "\n\t\t\t</Team>";
         }
 
         // create charlie team
@@ -487,7 +495,11 @@ void writeAvatarFile(const std::vector<Actor*> &alpha, const std::vector<Actor*>
             if (bravo.size() > 0) { ++idNumber;}
             (charlieTeam += '"') += QString::number(idNumber);
             charlieTeam += R"(" ScriptId = "0" Name = "_Charlie">)";
-            charlieTeam += charlieStrings[0] += charlieStrings[1] += charlieStrings[2] += "\n\t\t\t</Team>";
+            for (int i{0}; i < charlie.size(); ++i)
+            {
+                charlieTeam += charlieStrings[i];
+            }
+            charlieTeam += "\n\t\t\t</Team>";
         }
 
         // create platoon

--- a/platoonsetup.cpp
+++ b/platoonsetup.cpp
@@ -31,7 +31,7 @@ PlatoonSetup::PlatoonSetup(QWidget *parent) :
 {
     ui->setupUi(this);
     this->setWindowFlags(Qt::MSWindowsFixedSizeDialogHint); // removes resize arrows when hovering over the border
-    PlatoonSetup::grabKeyboard(); // send all keboard input to the main window to prevent messing up the selection logic of the fireteam/soldier pool boxes
+    PlatoonSetup::grabKeyboard(); // send all keboard input to the main window to disable user's use of keyboard
     ui->pteFireModes1->setLineWrapMode(QPlainTextEdit::LineWrapMode::NoWrap);
     ui->pteFireModes2->setLineWrapMode(QPlainTextEdit::LineWrapMode::NoWrap);
 
@@ -349,7 +349,23 @@ PlatoonSetup::PlatoonSetup(QWidget *parent) :
 
     // select first soldier (can only do this after actors and kits are loaded and processed)
     ui->lwSoldierPool->setCurrentRow(0);
-    on_lwSoldierPool_itemPressed();
+    // these next lines should be identical to what's executed in on_lwSoldierPool_currentItemChanged(), minus the check for user's mouse position
+    syncSoldierPoolWithFireteam(m_alpha, ui->lwAlpha);
+    syncSoldierPoolWithFireteam(m_bravo, ui->lwBravo);
+    syncSoldierPoolWithFireteam(m_charlie, ui->lwCharlie);
+    updateTeamButton(m_alpha, ui->pbAlpha);
+    updateTeamButton(m_bravo, ui->pbBravo);
+    updateTeamButton(m_charlie, ui->pbCharlie);
+    updateUnassignButton();
+
+    buildKitPool(getSelectedActorsKits());
+    selectActorsKit();
+    updateKitNameBox();
+    updateSelectedKitInfo(getSelectedActorsKits());
+    updateApplyKitToFireteamButton();
+    updateApplyKitToSquadButton();
+
+    updateSoldierDetails();
 
     // connect signals and slots
     QCoreApplication *coreApp{QCoreApplication::instance()};
@@ -440,24 +456,39 @@ void PlatoonSetup::on_pbCharlie_clicked()
     m_mediaPlayerButtonClick->play();
 }
 
-void PlatoonSetup::on_lwSoldierPool_itemPressed()
+void PlatoonSetup::on_lwSoldierPool_currentItemChanged()
 {
-    syncSoldierPoolWithFireteam(m_alpha, ui->lwAlpha);
-    syncSoldierPoolWithFireteam(m_bravo, ui->lwBravo);
-    syncSoldierPoolWithFireteam(m_charlie, ui->lwCharlie);
-    updateTeamButton(m_alpha, ui->pbAlpha);
-    updateTeamButton(m_bravo, ui->pbBravo);
-    updateTeamButton(m_charlie, ui->pbCharlie);
-    updateUnassignButton();
+    if (ui->lwSoldierPool->underMouse())
+    {
+        syncSoldierPoolWithFireteam(m_alpha, ui->lwAlpha);
+        syncSoldierPoolWithFireteam(m_bravo, ui->lwBravo);
+        syncSoldierPoolWithFireteam(m_charlie, ui->lwCharlie);
+        updateTeamButton(m_alpha, ui->pbAlpha);
+        updateTeamButton(m_bravo, ui->pbBravo);
+        updateTeamButton(m_charlie, ui->pbCharlie);
+        updateUnassignButton();
 
-    buildKitPool(getSelectedActorsKits());
-    selectActorsKit();
-    updateKitNameBox();
-    updateSelectedKitInfo(getSelectedActorsKits());
-    updateApplyKitToFireteamButton();
-    updateApplyKitToSquadButton();
+        buildKitPool(getSelectedActorsKits());
+        selectActorsKit();
+        updateKitNameBox();
+        updateSelectedKitInfo(getSelectedActorsKits());
+        updateApplyKitToFireteamButton();
+        updateApplyKitToSquadButton();
 
-    updateSoldierDetails();
+        updateSoldierDetails();
+    }
+}
+
+void PlatoonSetup::on_lwAlpha_itemEntered()
+{
+    ui->lwAlpha->setCurrentRow(m_alpha.size() - 1);
+    on_lwAlpha_itemPressed();
+}
+
+void PlatoonSetup::on_lwAlpha_currentItemChanged()
+{
+    if (ui->lwAlpha->underMouse())
+        on_lwAlpha_itemPressed();
 }
 
 void PlatoonSetup::on_lwAlpha_itemPressed()
@@ -480,6 +511,18 @@ void PlatoonSetup::on_lwAlpha_itemPressed()
     updateSoldierDetails();
 }
 
+void PlatoonSetup::on_lwBravo_itemEntered()
+{
+    ui->lwBravo->setCurrentRow(m_bravo.size() - 1);
+    on_lwBravo_itemPressed();
+}
+
+void PlatoonSetup::on_lwBravo_currentItemChanged()
+{
+    if (ui->lwBravo->underMouse())
+        on_lwBravo_itemPressed();
+}
+
 void PlatoonSetup::on_lwBravo_itemPressed()
 {
     syncFireteamWithSoldierPool(m_bravo, ui->lwBravo);
@@ -498,6 +541,18 @@ void PlatoonSetup::on_lwBravo_itemPressed()
     updateApplyKitToSquadButton();
 
     updateSoldierDetails();
+}
+
+void PlatoonSetup::on_lwCharlie_itemEntered()
+{
+    ui->lwCharlie->setCurrentRow(m_charlie.size() - 1);
+    on_lwCharlie_itemPressed();
+}
+
+void PlatoonSetup::on_lwCharlie_currentItemChanged()
+{
+    if (ui->lwCharlie->underMouse())
+        on_lwCharlie_itemPressed();
 }
 
 void PlatoonSetup::on_lwCharlie_itemPressed()
@@ -535,11 +590,14 @@ void PlatoonSetup::on_pbUnassign_clicked()
     m_mediaPlayerButtonClick->play();
 }
 
-void PlatoonSetup::on_lwKits_itemPressed()
+void PlatoonSetup::on_lwKits_currentItemChanged()
 {
-    updateKitNameBox();
-    updateSelectedKitInfo(getSelectedActorsKits());
-    setActorsKit(m_actors[ui->lwSoldierPool->currentRow()]);
+    if (ui->lwKits->underMouse())
+    {
+        updateKitNameBox();
+        updateSelectedKitInfo(getSelectedActorsKits());
+        setActorsKit(m_actors[ui->lwSoldierPool->currentRow()]);
+    }
 }
 
 void PlatoonSetup::on_pbKitLeft_clicked()

--- a/platoonsetup.h
+++ b/platoonsetup.h
@@ -37,17 +37,24 @@ private slots:
 
     void on_pbCharlie_clicked();
 
-    void on_lwSoldierPool_itemPressed();
+    // the list widget slots for alpha, bravo, charlie, the soldier pool, and the kit list are only allowed to fire on user interaction - not as a result of another function making selection changes to the lists
+    void on_lwSoldierPool_currentItemChanged();
 
-    void on_lwAlpha_itemPressed();
+    void on_lwAlpha_itemEntered(); // this is fired when user clicks into the selection box and the drags the mouse over on of the items(soldier names).  Without this the name would be highlighed but that soldier wouldn't actually be selected
+    void on_lwAlpha_currentItemChanged(); // this is fired when user clicks an item or is holding a click and drag selecting through items
+    void on_lwAlpha_itemPressed(); // this is fired when user clicks an item with left or right mouse button
 
+    void on_lwBravo_itemEntered();
+    void on_lwBravo_currentItemChanged();
     void on_lwBravo_itemPressed();
 
+    void on_lwCharlie_itemEntered();
+    void on_lwCharlie_currentItemChanged();
     void on_lwCharlie_itemPressed();
 
     void on_pbUnassign_clicked();
 
-    void on_lwKits_itemPressed();
+    void on_lwKits_currentItemChanged();
 
     void on_pbKitLeft_clicked();
 

--- a/platoonsetup.ui
+++ b/platoonsetup.ui
@@ -45,9 +45,6 @@ color: rgb(122, 162, 208);</string>
   </property>
   <widget class="QWidget" name="centralWidget">
    <widget class="QListWidget" name="lwSoldierPool">
-    <property name="enabled">
-     <bool>true</bool>
-    </property>
     <property name="geometry">
      <rect>
       <x>10</x>

--- a/variables.h
+++ b/variables.h
@@ -5,7 +5,7 @@
 #include <QString>
 
 
-constexpr int fireteamMaxMembers{3};
+constexpr int fireteamMaxMembers{6}; // the AI stops functioning when there is more than six members on a fireteam
 const QString actorExtension{".atr"};
 const QString gunExtension{".gun"};
 const QString projectileExtension{".prj"};


### PR DESCRIPTION
- Fixed issue where user could drag select in the soldier pool which would change the current index but not actually fire the "item pressed" signal.  In the case of selecting a soldier of a class with less available kits than the previously selected soldier, this would lead to a program crash if the user clicked through the kits using the push buttons until they fell out of the vector's range.  Selection logic in all the list widgets is improved now that drag selecting works as expected.

- Max members per fireteam has been increased to six which the game supports.  This makes it possible to bring up to 18 soldiers into the game which can both crash the game.  More testing/documenting to be done still but here is a brief rundown:
- more than six soldiers in the single player after action screen - crash
- more than nine soldiers in the ingame soldier roster - crash
If the player respects these limitations the game can be played in multiplayer mode with 18 soldiers to completion, including the after action screen.  In multiplayer mode soldiers 10 through 18 will just overflow into the next platoon's score tab.

- writeAvatarFile() has been improved to support any number of fireteam members, not just three as it was before.