### PR TITLE
10 05 18

### DIFF
--- a/functions.cpp
+++ b/functions.cpp
@@ -143,77 +143,7 @@ void readInAllKits(const std::string &kitsDirectoryPath, std::vector<Kit> &kitVe
         currentFile.close();
     }
 }
-/*
-void readInAllKits(const std::string &kitsDirectoryPath, std::vector<Kit> &kitVector)
-{
-    std::set<QString> discoveredKits;
-    for (auto it{fs::recursive_directory_iterator(kitsDirectoryPath)} ; it != fs::recursive_directory_iterator() ; ++it)
-    //for (const auto &element : fs::recursive_directory_iterator(kitsDirectoryPath))
-    {
-        fs::path relativePath{it->path().relative_path()};
-        fs::path fullPath{it->path()};
-        fs::path fileName{it->path().filename()};
-        if (QString::compare(QString::fromStdWString(it->path().relative_path()), "equip", Qt::CaseInsensitive) == 0)
-        //if (it->path().filename() == "equip")
-            it.disable_recursion_pending();
-        std::ifstream currentFile;
-        // first check this is a regular file before proceeding
-        // using the error code version to avoid exceptions being thrown
-        // but no actual error handling will take place with this error code
-        std::error_code errorCode;
-        if (fs::is_regular_file(it->path(), errorCode))
-        {
-            fs::path pathNoFilename{it->path()};
-            pathNoFilename.remove_filename();
-            QString curFilePath{QString::fromStdWString(pathNoFilename)};
-            QString curFileName{QString::fromStdWString(it->path().filename())};
-            if (QString::compare(getFileExtension(curFileName), kitExtension, Qt::CaseInsensitive) == 0)  // check this is a kit file
-            {
-                currentFile.open(it->path());
-                if (!currentFile.good())
-                {
-                    QString errorMsg{"Error in readInAllKits().  Failed to open file: "};
-                    errorMsg += QString::fromStdWString(it->path());
-                    QMessageBox msgBox(QMessageBox::Critical, "Error", errorMsg);
-                    msgBox.exec();
-                    exit(EXIT_FAILURE);
-                }
-                // now check if this kit file name has already been seen
-                std::set<QString>::const_iterator it{discoveredKits.cbegin()};
-                it = discoveredKits.find(curFileName);
-                if (it == discoveredKits.cend()) // kit file name hasn't been seen yet, proceed to check it against the passed in kit vector
-                {
-                    discoveredKits.insert(curFileName); // add this kit file name to the list of discovered kits
-                    bool replacedItem{false};
-                    for (auto &element2 : kitVector)
-                    {
-                        if (QString::compare(curFileName, element2.getFileName(), Qt::CaseInsensitive) == 0) // found a kit in the vector with same filename as this one, replace it with this new one
-                        {
-                            element2 = Kit(curFilePath, curFileName, currentFile);
-                            replacedItem = true;
-                        }
-                    }
-                    if (!replacedItem) // didn't find a kit in the vector with this name already so add in this new kit
-                    {
-                        kitVector.push_back(Kit(curFilePath, curFileName, currentFile));
-                    }
-                }
-                else // kit file name has been seen before so only add this new kit path to the kit
-                {
-                    for (auto &element2 : kitVector)
-                    {
-                        if (QString::compare(curFileName, element2.getFileName(), Qt::CaseInsensitive) == 0)
-                        {
-                            element2.addFilePath(curFilePath);
-                        }
-                    }
-                }
-            }
-        }
-        currentFile.close();
-    }
-}
-*/
+
 // adds kits from the passed in source kit vector to the destination kit vector based on whether or not a kit's path matches the passed in kit path
 void updateKitVectorPerKitPath(const QString &targetKitPath, const std::vector<Kit> &source, std::vector<Kit> &destination)
 {
@@ -360,7 +290,6 @@ void loadMod(const std::string &modPath, std::vector<Actor> &actors, Strings &st
     }
 
     // add/update any new kits discovered in this mod
-    //readInAllKits(modPath, tempKits);
     if (fs::is_directory(modPath + "\\Kits", errorCode))
         readInAllKits(modPath + "\\Kits", tempKits);
 

--- a/functions.h
+++ b/functions.h
@@ -33,10 +33,13 @@ void readInAllKits(const std::string &kitsDirectoryPath, std::vector<Kit> &kitVe
 // adds kits from the passed in source kit vector to the destination kit vector based on whether or not a kit's path matches the passed in kit path
 void updateKitVectorPerKitPath(const QString &targetKitPath, const std::vector<Kit> &source, std::vector<Kit> &destination);
 
-// adds/updates kits from passed in kit list to passed in soldier class specific kit vectors according to the passed in kit restriction list
+// adds/updates kits from passed in kit vector to passed in soldier class specific kit vectors according to the passed in kit restriction list
 // kits are checked one at a time and added to each soldier class that is a user of that kit
 // a kit could be used by more than one soldier class
 void updateKitVectorsPerRestrictionList(const std::vector<Kit> &allKits, const KitRestrictionList &kitList, std::vector<Kit> &riflemanKits, std::vector<Kit> &heavyWeaponsKits, std::vector<Kit> &sniperKits, std::vector<Kit> &demolitionsKits);
+
+// adds/updates kits from passed in kit vector to passed in soldier class specific kit vector according to the passed in kit restriction list
+void updateKitVectorPerRestrictionList(const std::vector<Kit> &allKits, const KitRestrictionList &kitList, const QString &soldierClass, std::vector<Kit> &soldierKitVector);
 
 // reads in actor, gun, projectile, or item files
 // pass in a directory where actor, gun, projectile, or item files are held, the file extension of the desired file type, and a vector of the desired file type to store the results

--- a/platoonsetup.cpp
+++ b/platoonsetup.cpp
@@ -88,11 +88,11 @@ PlatoonSetup::PlatoonSetup(QWidget *parent) :
         errorMessage += QString::fromStdString(mainGameDirectory) + "\\Mods\\Origmiss\\Actor\\demolitions";
     }
 
-    // randomly choose nine actors of each class and put them into the actors pool
-    if (rifleman.size() > 0) for (int i{0}; i < 76; ++i) { assignRandomActorToVector(rifleman, m_actors); }
-    if (heavyWeapons.size() > 0) for (int i{0}; i < 60; ++i) { assignRandomActorToVector(heavyWeapons, m_actors); }
-    if (sniper.size() > 0) for (int i{0}; i < 40; ++i) { assignRandomActorToVector(sniper, m_actors); }
-    if (demolitions.size() > 0) for (int i{0}; i < 59; ++i) { assignRandomActorToVector(demolitions, m_actors); }
+    // randomly choose 18 actors of each class and put them into the actors pool
+    if (rifleman.size() > 0) for (int i{0}; i < 18; ++i) { assignRandomActorToVector(rifleman, m_actors); }
+    if (heavyWeapons.size() > 0) for (int i{0}; i < 18; ++i) { assignRandomActorToVector(heavyWeapons, m_actors); }
+    if (sniper.size() > 0) for (int i{0}; i < 18; ++i) { assignRandomActorToVector(sniper, m_actors); }
+    if (demolitions.size() > 0) for (int i{0}; i < 18; ++i) { assignRandomActorToVector(demolitions, m_actors); }
 
     // read in strings
     if (fs::is_regular_file(mainGameDirectory + "\\Data\\Shell\\strings.txt", errorCode) && !errorLoadingBaseGameData)
@@ -273,10 +273,21 @@ PlatoonSetup::PlatoonSetup(QWidget *parent) :
     updateKitVectorPerKitPath(sniperKitPath, tempKits, m_sniperKits);
     updateKitVectorPerKitPath(demolitionsKitPath, tempKits, m_demolitionsKits);
 
-    // add kits from the quick_missions.qmk file only if all four soldier classes are using the default kit paths
+    // add kits from the quick_missions.qmk file to all four soldier classes at the same time if all four are using the default kit paths
     if (riflemanKitPath == defaultRiflemanKitPath && supportKitPath == defaultSupportKitPath && sniperKitPath == defaultSniperKitPath && demolitionsKitPath == defaultDemolitionsKitPath)
     {
         updateKitVectorsPerRestrictionList(tempKits, kitList, m_riflemanKits, m_heavyWeaponsKits, m_sniperKits, m_demolitionsKits);
+    }
+    else // otherwise check each class individually and add kits if that particular class is using the default kit path
+    {
+        if (riflemanKitPath == defaultRiflemanKitPath)
+            updateKitVectorPerRestrictionList(tempKits, kitList, classRifleman, m_riflemanKits);
+        if (supportKitPath == defaultSupportKitPath)
+            updateKitVectorPerRestrictionList(tempKits, kitList, classHeavyWeapons, m_heavyWeaponsKits);
+        if (sniperKitPath == defaultSniperKitPath)
+            updateKitVectorPerRestrictionList(tempKits, kitList, classSniper, m_sniperKits);
+        if (demolitionsKitPath == defaultDemolitionsKitPath)
+            updateKitVectorPerRestrictionList(tempKits, kitList, classDemolitions, m_demolitionsKits);
     }
 
     // check that each soldier class has at least one kit in their kit vector and close program if not (must do after loading mods as mods may add kits)

--- a/variables.h
+++ b/variables.h
@@ -20,8 +20,8 @@ const QString defaultRiflemanKitPath{"rifleman"};
 const QString defaultSupportKitPath{"heavy-weapons"};
 const QString defaultSniperKitPath{"sniper"};
 const QString defaultDemolitionsKitPath{"demolitions"};
-const std::string mainGameDirectory{"C:\\Program Files (x86)\\Red Storm Entertainment\\Ghost Recon"};
-//const std::string mainGameDirectory{"..\\"};
+//const std::string mainGameDirectory{"C:\\Program Files (x86)\\Red Storm Entertainment\\Ghost Recon"};
+const std::string mainGameDirectory{"..\\"};
 // ***switch main game directory to realitive path for release build***
 
 enum class fileReadResult


### PR DESCRIPTION
- Added function updateKitVectorPerRestrictionList() which differs from updateKitVectorsPerRestrictionList() in that it takes and processes one kit vector at a time.  The one that does all four kit vectors is probably more efficient but this new singular one is more flexible.

- There is now two scenarios for how the kit restriction list is processed.  If all four soldier classes are using the default kit paths, updateKitVectorsPerRestrictionList() is called and all four are processed at the same time.  If not, than each soldier class is looked at individually and processed if it is using the default kit path.  The game treats them individually as well so the previous 'all four classes or none of them' implementation was incorrect.

- In loadMod(), the code now only calls readInAllKits() if there is a "kits" directory in the mod.  This differs from the game as the game can process kits from anywhere within a mod.  This change was made to reduce loading times of community mods as now enemy soldier kits in the "equip" directory will be ignored.  Mod testing has shown no issues with only checking "kits" for new player kits.

- The amount of soldiers of each class to choose from has been raised from nine to 18.  This is because the user can choose up to 18 soldiers now so the tool should provide the option of using 18 soldiers of the same class.